### PR TITLE
feat: add Ctrl-F/Ctrl-B page scrolling to TUI parts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For more details or to discuss releases, please visit the
 
 ## [Unreleased]
 
+- TUI: the parts list now scrolls a full page at a time with Ctrl-F (forward)
+  and Ctrl-B (back), matching the less and vim convention.
+
 ## [0.9.0] - 2026-07-14
 
 - KiCad HTTP API: the server now watches the partmaster directory and reloads

--- a/tui.go
+++ b/tui.go
@@ -187,6 +187,13 @@ func initialModelNew(needsPMDir bool, pmDir string, updateMsg string) modelNew {
 		table.WithFocused(false),
 	)
 
+	// Add ctrl+f/ctrl+b as full-page scroll aliases, matching the
+	// less/vim convention, alongside the table's default f/b and pgup/pgdown.
+	km := table.DefaultKeyMap()
+	km.PageDown.SetKeys(append(km.PageDown.Keys(), "ctrl+f")...)
+	km.PageUp.SetKeys(append(km.PageUp.Keys(), "ctrl+b")...)
+	t.KeyMap = km
+
 	s := table.DefaultStyles()
 	s.Header = s.Header.
 		BorderStyle(lipgloss.NormalBorder()).
@@ -1380,7 +1387,7 @@ func (m modelNew) View() string {
 			if m.selectedFile == allFilesOption {
 				enterLabel = "Enter open file"
 			}
-			parts := []string{enterLabel, "/ search", "p parametric"}
+			parts := []string{enterLabel, "^F/^B page", "/ search", "p parametric"}
 			if m.selectedFile != allFilesOption {
 				parts = append(parts, "o datasheet")
 			}


### PR DESCRIPTION
Extend the parts table's PageUp/PageDown keybindings with ctrl+b and ctrl+f so the list scrolls a full page at a time, matching the less and vim convention. Add a footer hint and a CHANGELOG entry.